### PR TITLE
Fix box-shadow overflowing in the title box of the cards in Safari

### DIFF
--- a/styles/public/card-containers.scss
+++ b/styles/public/card-containers.scss
@@ -67,7 +67,7 @@
 			width: 100%;
 			padding: 0;
 			overflow: hidden;
-			-webkit-mask-image: -webkit-radial-gradient(white, black); // Safari fix
+			mask: radial-gradient(white, black); // Safari overflow fix
 
 			.wp-block-cover__background {
 				display: none;

--- a/styles/public/card-containers.scss
+++ b/styles/public/card-containers.scss
@@ -67,6 +67,7 @@
 			width: 100%;
 			padding: 0;
 			overflow: hidden;
+			-webkit-mask-image: -webkit-radial-gradient(white, black); // Safari fix
 
 			.wp-block-cover__background {
 				display: none;


### PR DESCRIPTION
Small CSS fix to resolve this issue for Safari:
![image](https://github.com/user-attachments/assets/303d8b28-6ec5-4815-a9ab-a9e5c4a41d36)
